### PR TITLE
Add support for basic auth endpoints (e.g. JWT tokens)

### DIFF
--- a/lib/primetrust.ex
+++ b/lib/primetrust.ex
@@ -21,12 +21,12 @@ defmodule PrimeTrust do
 
   defmodule MissingApiUrlError do
     defexception message: """
-                 The `api_url` for the PrimeTrust API was not set. Please set one of the
+                 The `base_api_url` for the PrimeTrust API was not set. Please set one of the
                  following URLs in your `config.exs`, depending on what environment you
                  are using.
 
-                 config :optimus, api_url: "https://sandbox.primetrust.com/v2" # sandbox
-                 config :optimus, api_url: "https://api.primetrust.com/v2" # production
+                 config :optimus, api_url: "https://sandbox.primetrust.com" # sandbox
+                 config :optimus, api_url: "https://api.primetrust.com" # production
                  """
   end
 

--- a/lib/primetrust/auth/jwt.ex
+++ b/lib/primetrust/auth/jwt.ex
@@ -1,0 +1,32 @@
+defmodule PrimeTrust.Auth.JWT do
+  @moduledoc """
+  Work with PrimeTrust JWT.
+
+  The JWT request end-point does not follow the same REST design as the majority
+  of the PrimeTrust API, so `auth/jwts` is handled via Basic authentication
+  and without going through the normal `PrimeTrust.API.req` method, which
+  does additional things like specify API version in the URL.
+  """
+  alias PrimeTrust.API
+
+  @resource "auth/jwts"
+
+  @type t :: %__MODULE__{
+          token: String.t()
+        }
+
+  defstruct [:token]
+
+  @spec create_jwt(iodata(), iodata()) :: {:ok, t} | {:error, map}
+  def create_jwt(email, password) do
+    API.basic_req(:post, @resource, email, password)
+  end
+
+  @doc """
+  Utility to invalidate the current JWT.
+  """
+  @spec invalidate() :: {:ok, map} | {:error, map}
+  def invalidate() do
+    API.req(:post, @resource <> "/invalidate-session", %{}, <<>>, [])
+  end
+end


### PR DESCRIPTION
There are a few endpoints in the PrimeTrust API that don't follow their normal RESTful model, like /auth/jwts, so this adds a method basic_req to PrimeTrust.API that allows a request to be made to those endpoints.

This also adds a helper to generate a new JWT from a user's credentials.