### PR TITLE
replace api config for email/pwd

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,3 @@
+import Config
+
+import_config "#{config_env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,4 +1,11 @@
 import Config
 
 config :logger,
-  level: :warning
+  level: :debug
+
+config :optimus,
+  email: "your@email.com",
+  password: "your_password"
+
+# sandbox
+config :optimus, base_api_url: "https://sandbox.primetrust.com"

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,1 @@
+import Config

--- a/lib/primetrust/auth/jwt.ex
+++ b/lib/primetrust/auth/jwt.ex
@@ -11,13 +11,7 @@ defmodule PrimeTrust.Auth.JWT do
 
   @resource "auth/jwts"
 
-  @type t :: %__MODULE__{
-          token: String.t()
-        }
-
-  defstruct [:token]
-
-  @spec create_jwt(iodata(), iodata()) :: {:ok, t} | {:error, map}
+  @spec create_jwt(binary, binary) :: {:ok, map}
   def create_jwt(email, password) do
     API.basic_req(:post, @resource, email, password)
   end
@@ -28,5 +22,17 @@ defmodule PrimeTrust.Auth.JWT do
   @spec invalidate() :: {:ok, map} | {:error, map}
   def invalidate() do
     API.req(:post, @resource <> "/invalidate-session", %{}, <<>>, [])
+  end
+
+  @spec set_jwt :: :ok
+  def set_jwt do
+    email = Application.get_env(:optimus, :email) || raise PrimeTrust.MissingCredentialsError
+
+    password =
+      Application.get_env(:optimus, :password) || raise PrimeTrust.MissingCredentialsError
+
+    {:ok, %{"token" => token}} = create_jwt(email, password)
+
+    Application.put_env(:optimus, :api_token, token)
   end
 end

--- a/lib/primetrust/token_management.ex
+++ b/lib/primetrust/token_management.ex
@@ -1,0 +1,38 @@
+defmodule PrimeTrust.TokenManagement do
+  @moduledoc """
+  Responsable for renewing JWT token.
+  Every 8 hours by default.
+
+  Can be modified in config
+
+  ```
+  config :optimus,
+     renew_jwt_time_interval: 3000 # 3 sec.
+  ```
+  """
+  use GenServer, restart: :transient
+
+  require Logger
+
+  def start_link(run_interval) do
+    PrimeTrust.Auth.JWT.set_jwt()
+    GenServer.start_link(__MODULE__, run_interval, name: __MODULE__)
+  end
+
+  @impl true
+  def init(run_interval) do
+    {:ok, run_interval, {:continue, :schedule_next_run}}
+  end
+
+  @impl true
+  def handle_continue(:schedule_next_run, run_interval) do
+    Process.send_after(self(), :perform_cron_work, run_interval)
+    {:noreply, run_interval}
+  end
+
+  @impl true
+  def handle_info(:perform_cron_work, run_interval) do
+    PrimeTrust.Auth.JWT.set_jwt()
+    {:noreply, run_interval, {:continue, :schedule_next_run}}
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,8 @@ defmodule Optimus.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger],
+      mod: {PrimeTrust, [env: Mix.env()]}
     ]
   end
 


### PR DESCRIPTION
Implementation of a Genserver to keep the token 

- Created when the lib is started
- Renewed (recreated with Basic Auth) every 8 hours 

1 weird thing I had to make: 

Passing the env (`:test`) as a variable to avoid starting the genserver when running test. 

A better solution, have the HTTP client segregated, so it can be
1. adjusted in config, therefore easier to mock and adapt for testing. 
2. swapped out. (probably not).  But seriously, if performance is something that is crucial here, we never know. 

Example of this approach from ex_aws: 
[Client](https://github.com/ex-aws/ex_aws/blob/main/lib/ex_aws/request/http_client.ex)
[Hackney impl](https://github.com/ex-aws/ex_aws/blob/main/lib/ex_aws/request/hackney.ex)


BTW, the most relevant thing I have read about elixir/erlang clients can be found [here](https://elixirforum.com/t/mint-vs-finch-vs-gun-vs-tesla-vs-httpoison-etc/38588/11?)











