### PR TITLE
API.req - Turn body and header into keyword opts

### DIFF
--- a/lib/primetrust/accounts.ex
+++ b/lib/primetrust/accounts.ex
@@ -68,14 +68,14 @@ defmodule PrimeTrust.Accounts do
   Fetches the `/accounts` index
   """
   def list(opts \\ []) do
-    API.req(:get, @resource, %{}, <<>>, opts)
+    API.req(:get, @resource, opts)
   end
 
   @doc """
   Fetches a single account by its Prime Trust ID (an UUIDv4).
   """
   def get(id, opts \\ []) do
-    API.req(:get, @resource <> "/#{id}", %{}, <<>>, opts)
+    API.req(:get, @resource <> "/#{id}", opts)
   end
 
   @doc """
@@ -88,6 +88,12 @@ defmodule PrimeTrust.Accounts do
                :owner => map
              }
   def create_personal(%{name: _, authorized_signature: _, owner: _} = params, opts \\ []) do
-    API.req(:post, @resource, %{}, params, [{:api_type, @api_type} | opts])
+    opts =
+      [
+        {:api_type, @api_type},
+        {:body, params}
+      ] ++ opts
+
+    API.req(:post, @resource, opts)
   end
 end

--- a/lib/primetrust/api.ex
+++ b/lib/primetrust/api.ex
@@ -81,10 +81,13 @@ defmodule PrimeTrust.API do
   Make request to the PrimeTrust API, using standard Bearer token
   authentication.
   """
-  @spec req(method, resource :: String.t(), headers :: map, body :: map | binary(), opts :: list) ::
-          {:ok, map} | {:error, map}
-  def req(:get, resource, headers, body, opts) do
+  @spec req(method, resource :: String.t(), opts :: Keyword.t()) :: {:ok, map} | {:error, map}
+  def req(method, resource, opts \\ [])
+
+  def req(:get, resource, opts) do
     {use_api_version, opts} = Keyword.pop(opts, :use_api_version, true)
+    {headers, opts} = Keyword.pop(opts, :headers, %{})
+    {body, opts} = Keyword.pop(opts, :body, <<>>)
     {includes, opts} = Keyword.pop(opts, :include)
 
     request_url =
@@ -95,9 +98,11 @@ defmodule PrimeTrust.API do
     make_request(:get, request_url, headers, body, opts)
   end
 
-  def req(method, resource, headers, body, opts) do
+  def req(method, resource, opts) do
     {use_api_version, opts} = Keyword.pop(opts, :use_api_version, true)
     {api_type, opts} = Keyword.pop(opts, :api_type, <<>>)
+    {headers, opts} = Keyword.pop(opts, :headers, %{})
+    {body, opts} = Keyword.pop(opts, :body, <<>>)
     {includes, opts} = Keyword.pop(opts, :include)
 
     request_url =

--- a/lib/primetrust/assets/asset.ex
+++ b/lib/primetrust/assets/asset.ex
@@ -13,7 +13,7 @@ defmodule PrimeTrust.Asset do
   """
   @spec list(Keyword.t()) :: {:ok, map} | {:error | map}
   def list(opts \\ []) do
-    API.req(:get, @resource, %{}, <<>>, opts)
+    API.req(:get, @resource, opts)
   end
 
   @doc """
@@ -21,7 +21,7 @@ defmodule PrimeTrust.Asset do
   """
   @spec get(binary, Keyword.t()) :: {:ok, map} | {:error | map}
   def get(id, opts \\ []) do
-    API.req(:get, @resource <> "/#{id}", %{}, <<>>, opts)
+    API.req(:get, @resource <> "/#{id}", opts)
   end
 
   @doc """
@@ -29,7 +29,13 @@ defmodule PrimeTrust.Asset do
   """
   @spec create(map, Keyword.t()) :: {:ok, map} | {:error, map}
   def create(params, opts \\ []) do
-    API.req(:post, @resource, %{}, params, [{:api_type, @api_type} | opts])
+    opts =
+      [
+        {:api_type, @api_type},
+        {:body, params}
+      ] ++ opts
+
+    API.req(:post, @resource, opts)
   end
 
   @doc """
@@ -37,6 +43,12 @@ defmodule PrimeTrust.Asset do
   """
   @spec update(binary, map, Keyword.t()) :: {:ok, map} | {:error, map}
   def update(id, params, opts \\ []) do
-    API.req(:patch, @resource <> "/#{id}", %{}, params, [{:api_type, @api_type} | opts])
+    opts =
+      [
+        {:api_type, @api_type},
+        {:body, params}
+      ] ++ opts
+
+    API.req(:patch, @resource <> "/#{id}", opts)
   end
 end

--- a/lib/primetrust/assets/contribution.ex
+++ b/lib/primetrust/assets/contribution.ex
@@ -14,7 +14,7 @@ defmodule PrimeTrust.AssetContribution do
   """
   @spec list(Keyword.t()) :: {:ok, map} | {:error | map}
   def list(opts \\ []) do
-    API.req(:get, @resource, %{}, <<>>, opts)
+    API.req(:get, @resource, opts)
   end
 
   @doc """
@@ -22,7 +22,7 @@ defmodule PrimeTrust.AssetContribution do
   """
   @spec get(binary, Keyword.t()) :: {:ok, map} | {:error | map}
   def get(id, opts \\ []) do
-    API.req(:get, @resource <> "/#{id}", %{}, <<>>, opts)
+    API.req(:get, @resource <> "/#{id}", opts)
   end
 
   @doc """
@@ -30,6 +30,12 @@ defmodule PrimeTrust.AssetContribution do
   """
   @spec create(map, Keyword.t()) :: {:ok, map} | {:error, map}
   def create(params, opts \\ []) do
-    API.req(:post, @resource, %{}, params, [{:api_type, @api_type} | opts])
+    opts =
+      [
+        {:api_type, @api_type},
+        {:body, params}
+      ] ++ opts
+
+    API.req(:post, @resource, opts)
   end
 end

--- a/lib/primetrust/assets/disbursement.ex
+++ b/lib/primetrust/assets/disbursement.ex
@@ -14,7 +14,7 @@ defmodule PrimeTrust.AssetDisbursement do
   """
   @spec list(Keyword.t()) :: {:ok, map} | {:error | map}
   def list(opts \\ []) do
-    API.req(:get, @resource, %{}, <<>>, opts)
+    API.req(:get, @resource, opts)
   end
 
   @doc """
@@ -22,7 +22,7 @@ defmodule PrimeTrust.AssetDisbursement do
   """
   @spec get(binary, Keyword.t()) :: {:ok, map} | {:error | map}
   def get(id, opts \\ []) do
-    API.req(:get, @resource <> "/#{id}", %{}, <<>>, opts)
+    API.req(:get, @resource <> "/#{id}", opts)
   end
 
   @doc """
@@ -30,6 +30,12 @@ defmodule PrimeTrust.AssetDisbursement do
   """
   @spec create(map, Keyword.t()) :: {:ok, map} | {:error, map}
   def create(params, opts \\ []) do
-    API.req(:post, @resource, %{}, params, [{:api_type, @api_type} | opts])
+    opts =
+      [
+        {:api_type, @api_type},
+        {:body, params}
+      ] ++ opts
+
+    API.req(:post, @resource, opts)
   end
 end

--- a/lib/primetrust/assets/transaction.ex
+++ b/lib/primetrust/assets/transaction.ex
@@ -13,7 +13,7 @@ defmodule PrimeTrust.AssetTransaction do
   """
   @spec list(Keyword.t()) :: {:ok, map} | {:error, map}
   def list(opts \\ []) do
-    API.req(:get, @resource, %{}, <<>>, opts)
+    API.req(:get, @resource, opts)
   end
 
   @doc """
@@ -21,6 +21,6 @@ defmodule PrimeTrust.AssetTransaction do
   """
   @spec get(binary, Keyword.t()) :: {:ok, map} | {:error, map}
   def get(id, opts \\ []) do
-    API.req(:get, @resource <> "/#{id}", %{}, <<>>, opts)
+    API.req(:get, @resource <> "/#{id}", opts)
   end
 end

--- a/lib/primetrust/assets/transfer_method.ex
+++ b/lib/primetrust/assets/transfer_method.ex
@@ -13,7 +13,7 @@ defmodule PrimeTrust.AssetTransferMethod do
   """
   @spec list(Keyword.t()) :: {:ok, map} | {:error, map}
   def list(opts \\ []) do
-    API.req(:get, @resource, %{}, <<>>, opts)
+    API.req(:get, @resource, opts)
   end
 
   @doc """
@@ -21,7 +21,7 @@ defmodule PrimeTrust.AssetTransferMethod do
   """
   @spec get(binary, Keyword.t()) :: {:ok, map} | {:error, map}
   def get(id, opts \\ []) do
-    API.req(:get, @resource <> "/#{id}", %{}, <<>>, opts)
+    API.req(:get, @resource <> "/#{id}", opts)
   end
 
   @doc """
@@ -29,7 +29,13 @@ defmodule PrimeTrust.AssetTransferMethod do
   """
   @spec create(map, Keyword.t()) :: {:ok, map} | {:error, map}
   def create(params, opts \\ []) do
-    API.req(:post, @resource, %{}, params, [{:api_type, @api_type} | opts])
+    opts =
+      [
+        {:api_type, @api_type},
+        {:body, params}
+      ] ++ opts
+
+    API.req(:post, @resource, opts)
   end
 
   @doc """
@@ -37,6 +43,12 @@ defmodule PrimeTrust.AssetTransferMethod do
   """
   @spec update(binary, map, Keyword.t()) :: {:ok, map} | {:error, map}
   def update(id, params, opts \\ []) do
-    API.req(:patch, @resource <> "/#{id}", %{}, params, [{:api_type, @api_type} | opts])
+    opts =
+      [
+        {:api_type, @api_type},
+        {:body, params}
+      ] ++ opts
+
+    API.req(:patch, @resource <> "/#{id}", opts)
   end
 end

--- a/lib/primetrust/auth/jwt.ex
+++ b/lib/primetrust/auth/jwt.ex
@@ -28,7 +28,7 @@ defmodule PrimeTrust.Auth.JWT do
   """
   @spec get_info() :: {:ok, t} | {:error, map}
   def get_info() do
-    API.req(:get, @resource <> "/current", %{}, <<>>, use_api_version: false)
+    API.req(:get, @resource <> "/current", use_api_version: false)
   end
 
   @doc """
@@ -36,6 +36,6 @@ defmodule PrimeTrust.Auth.JWT do
   """
   @spec invalidate() :: {:ok, map} | {:error, map}
   def invalidate() do
-    API.req(:post, "users/current/jwts/invalidate", %{}, <<>>, [])
+    API.req(:post, "users/current/jwts/invalidate")
   end
 end

--- a/lib/primetrust/contacts/contact.ex
+++ b/lib/primetrust/contacts/contact.ex
@@ -14,7 +14,7 @@ defmodule PrimeTrust.Contact do
   """
   @spec list(Keyword.t()) :: {:ok, map} | {:error, map}
   def list(opts \\ []) do
-    API.req(:get, @resource, %{}, <<>>, opts)
+    API.req(:get, @resource, opts)
   end
 
   @doc """
@@ -22,7 +22,7 @@ defmodule PrimeTrust.Contact do
   """
   @spec get(Keyword.t()) :: {:ok, map} | {:error, map}
   def get(id, opts \\ []) do
-    API.req(:get, @resource <> "/#{id}", %{}, <<>>, opts)
+    API.req(:get, @resource <> "/#{id}", opts)
   end
 
   @doc """
@@ -32,7 +32,13 @@ defmodule PrimeTrust.Contact do
   """
   @spec create(map, Keyword.t()) :: {:ok, map} | {:error, map}
   def create(%{account_id: _, name: _} = params, opts \\ []) do
-    API.req(:post, @resource, %{}, params, [{:api_type, @api_type} | opts])
+    opts =
+      [
+        {:api_type, @api_type},
+        {:body, params}
+      ] ++ opts
+
+    API.req(:post, @resource, opts)
   end
 
   @doc """
@@ -40,7 +46,7 @@ defmodule PrimeTrust.Contact do
   """
   @spec delete(binary, Keyword.t()) :: {:ok, map} | {:error, map}
   def delete(id, opts \\ []) do
-    API.req(:delete, @resource <> "/#{id}", %{}, <<>>, opts)
+    API.req(:delete, @resource <> "/#{id}", opts)
   end
 
   @doc """
@@ -51,6 +57,6 @@ defmodule PrimeTrust.Contact do
   """
   @spec required_kyc_actions(binary, Keyword.t()) :: {:ok, map} | {:error, map}
   def required_kyc_actions(id, opts \\ []) do
-    API.req(:post, @resource <> "/#{id}/kyc-required-actions", %{}, <<>>, opts)
+    API.req(:post, @resource <> "/#{id}/kyc-required-actions", opts)
   end
 end

--- a/lib/primetrust/uploaded_documents.ex
+++ b/lib/primetrust/uploaded_documents.ex
@@ -65,14 +65,14 @@ defmodule PrimeTrust.UploadedDocuments do
   Fetches the `/uploaded_documents` index
   """
   def list(opts \\ []) do
-    API.req(:get, @resource, %{}, <<>>, opts)
+    API.req(:get, @resource, opts)
   end
 
   @doc """
   Fetches a single account by its Prime Trust ID (an UUIDv4).
   """
   def get(id, opts \\ []) do
-    API.req(:get, @resource <> "/#{id}", %{}, <<>>, opts)
+    API.req(:get, @resource <> "/#{id}", opts)
   end
 
   @doc """
@@ -84,6 +84,12 @@ defmodule PrimeTrust.UploadedDocuments do
                :contact_id => String.t()
              }
   def create_per_contact(%{file: _, contact_id: _} = params, opts \\ []) do
-    API.req(:post, @resource, %{}, params, [{:api_type, @api_type} | opts])
+    opts =
+      [
+        {:api_type, @api_type},
+        {:body, params}
+      ] ++ opts
+
+    API.req(:post, @resource, opts)
   end
 end

--- a/test/primetrust/api_test.exs
+++ b/test/primetrust/api_test.exs
@@ -16,8 +16,10 @@ defmodule PrimeTrust.APITest do
 
   describe "PrimeTrust.API.req" do
     test "Unset API key raises MissingApiUrlError" do
+      Application.delete_env(:optimus, :base_api_url)
+
       assert_raise PrimeTrust.MissingApiUrlError, fn ->
-        PrimeTrust.API.req(:get, "", %{}, %{}, [])
+        PrimeTrust.API.req(:get, "")
       end
     end
   end


### PR DESCRIPTION
Turns out that most callees of API.req basically never need to specify headers, body, or even custom opts of any kind, so this changes:

* `PrimeTrust.API.req\5` to `PrimeTrust.API.req\3`
* Moves `body` and `headers` into respective `keyword` args in `opts`
* Makes `opts \\ []` default on `API.req`.