### PR TITLE
fix param type for Accounts.create_personal

### DIFF
--- a/lib/primetrust/accounts.ex
+++ b/lib/primetrust/accounts.ex
@@ -81,12 +81,7 @@ defmodule PrimeTrust.Accounts do
   @doc """
   Create a Personal Custodial Account.
   """
-  @spec create_personal(params, Keyword.t()) :: {:ok, t} | {:error, map}
-        when params: %{
-               :name => String.t(),
-               :authorized_signature => String.t(),
-               :owner => map
-             }
+  @spec create_personal(params :: map, opts :: Keyword.t()) :: {:ok, t} | {:error, map}
   def create_personal(%{name: _, authorized_signature: _, owner: _} = params, opts \\ []) do
     opts =
       [


### PR DESCRIPTION
The type as currently defined is missing `account_type` and we don't quite know enough to specify the type rigorously for now anyway.